### PR TITLE
Add CNAME file for docs.r-e.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.rust-embedded.org


### PR DESCRIPTION
See https://github.com/rust-embedded/wg/issues/208 - Github keeps clearing the custom domain setting.