### PR TITLE
Use latest version of mdbook in CI

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -3,11 +3,10 @@ set -euxo pipefail
 main() {
     local tag=$(git ls-remote --tags --refs --exit-code https://github.com/rust-lang-nursery/mdbook \
                     | cut -d/ -f3 \
-                    | grep -E '^v0.2.[0-9]+$' \
+                    | grep -E '^v[0-9\.]+$' \
                     | sort --version-sort \
                     | tail -n1)
-    # Temporarily use older version until packages are available for 0.2.2 (or newer)
-    local tag="v0.2.1"
+
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- --git rust-lang-nursery/mdbook --tag $tag
 


### PR DESCRIPTION
Fixes #20 

Fixes #8

As discussed in https://github.com/rust-embedded/book/pull/212, this is causing rendering differences  between the rendered book from https://docs.rust-embedded.org/book/ and https://rust-embedded.github.io/book/.

Probably this shouldn't be merged until the reference PR is, as without it attributes will be erroneously hidden in some examples.