### PR TITLE
Fix broken book publishing on Travis

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,15 +1,18 @@
 set -euxo pipefail
 
 main() {
-    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/rust-lang-nursery/mdbook \
+    local tag=$(git ls-remote --tags --refs --exit-code \
+                    https://github.com/rust-lang/mdbook \
                     | cut -d/ -f3 \
-                    | grep -E '^v0.2.[0-9]+$' \
+                    | grep -E '^v[0-9\.]+$' \
                     | sort --version-sort \
                     | tail -n1)
-    # Temporarily use older version until packages are available for 0.2.2 (or newer)
-    local tag="v0.2.1"
+
     curl -LSfs https://japaric.github.io/trust/install.sh | \
-        sh -s -- --git rust-lang-nursery/mdbook --tag $tag
+        sh -s -- \
+           --force \
+           --git rust-lang/mdbook \
+           --tag $tag
 
     pip install linkchecker --user
 }

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -50,7 +50,7 @@ main() {
 
     # check links
     # FIXME(rust-lang-nursery/mdbook#789) remove `--ignore-url` when that bug is fixed
-    linkchecker --ignore-url "print.html" doc
+    # linkchecker --ignore-url "print.html" doc
 }
 
 main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -50,7 +50,7 @@ main() {
 
     # check links
     # FIXME(rust-lang-nursery/mdbook#789) remove `--ignore-url` when that bug is fixed
-    # linkchecker --ignore-url "print.html" doc
+    linkchecker --ignore-url "print.html" doc
 }
 
 main


### PR DESCRIPTION
The books were not published on https://docs.rust-embedded.org/ since March 16 2020. Last successful build [here](https://travis-ci.org/github/rust-embedded/docs/builds/662804843), first broken build [here](https://travis-ci.org/github/rust-embedded/docs/builds/663216351). [Here](https://travis-ci.org/github/rust-embedded/docs/builds) you can see the long list of failures.

I took the changes from https://github.com/rust-embedded/discovery/blob/d42012eedb4216ae8b613c3fdfdb37f85f01656f/ci/install.sh .

For proof that the changes fix the issue see my fork in https://github.com/yerke/docs, which was successfully built with Travis in [here](https://travis-ci.com/github/yerke/docs/builds/174282136). You can see built artifacts at https://github.com/yerke/yerke.github.io/tree/gh-pages and https://yerke.github.io .

Closes https://github.com/rust-embedded/docs/issues/8, https://github.com/rust-embedded/wg/issues/457, https://github.com/rust-embedded/discovery/issues/253