### PR TITLE
Add OS dev in Rust on Raspberry Pi book

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ The source code of the books is not in this repository; each book has its own
 repository which you can find listed below:
 
 - [The Discovery book](https://github.com/rust-embedded/discovery)
-- [The embedded Rust book](https://github.com/rust-embedded/book)
-- [The embedonomicon](https://github.com/rust-embedded/embedonomicon)
+- [The Embedded Rust book](https://github.com/rust-embedded/book)
+- [The Embedonomicon](https://github.com/rust-embedded/embedonomicon)
+- [Operating System development tutorials in Rust on the Raspberry Pi](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials)
 
 # `further resources`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ repository which you can find listed below:
 - [The Discovery book](https://github.com/rust-embedded/discovery)
 - [The Embedded Rust book](https://github.com/rust-embedded/book)
 - [The Embedonomicon](https://github.com/rust-embedded/embedonomicon)
-- [Operating System development tutorials in Rust on the Raspberry Pi](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials)
 
 # `further resources`
 
@@ -21,6 +20,7 @@ Here're some additional resources maintained by the [Resources team][team] which
 - [The Embedded Rust Showcase](https://rust-embedded.github.io/showcase/)
 - [The Awesome Embedded Rust list](https://github.com/rust-embedded/awesome-embedded-rust)
 - [The not-yet-awesome-embedded-rust (or NYAER) list](https://github.com/rust-embedded/not-yet-awesome-embedded-rust)
+- [Operating System development tutorials in Rust on the Raspberry Pi](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials)
 
 ## License
 

--- a/index.md
+++ b/index.md
@@ -69,3 +69,21 @@ language features that let you control the ABI of crates by creating a `no_std`
 program for the ARM Cortex-M architecture from scratch.
 
 [The embedonomicon]:embedonomicon/index.html
+
+# Write Operating System in embedded Rust
+
+If you are interested in Operating Systems and embedded Rust development, you
+may find these resources useful.
+
+## Operating System development tutorials in Rust on the Raspberry Pi
+
+[Operating System development tutorials in Rust on the Raspberry Pi] is a
+tutorial series for hobby OS developers who are new to ARM's 64 bit ARMv8-A
+architecture. The tutorials will give a guided, step-by-step tour of how to
+write a monolithic Operating System kernel for an embedded system from
+scratch. They cover implementation of common Operating Systems tasks, like
+writing to the serial console, setting up virtual memory and handling hardware
+exceptions. All while leveraging Rust's unique features to provide for safety
+and speed.
+
+[Operating System development tutorials in Rust on the Raspberry Pi]: https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials

--- a/index.md
+++ b/index.md
@@ -42,6 +42,19 @@ correct embedded software.
 
 [book]: book/index.html
 
+## Operating System development tutorials in Rust on the Raspberry Pi
+
+[Operating System development tutorials in Rust on the Raspberry Pi] is a
+tutorial series for hobby OS developers who are new to ARM's 64 bit ARMv8-A
+architecture. The tutorials will give a guided, step-by-step tour of how to
+write a monolithic Operating System kernel for an embedded system from
+scratch. They cover implementation of common Operating Systems tasks, like
+writing to the serial console, setting up virtual memory and handling hardware
+exceptions. All while leveraging Rust's unique features to provide for safety
+and speed.
+
+[Operating System development tutorials in Rust on the Raspberry Pi]: https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials
+
 ## Frequently Asked Questions
 
 You can find our list of FAQ [here](faq.html).
@@ -69,21 +82,3 @@ language features that let you control the ABI of crates by creating a `no_std`
 program for the ARM Cortex-M architecture from scratch.
 
 [The embedonomicon]:embedonomicon/index.html
-
-# Write Operating System in embedded Rust
-
-If you are interested in Operating Systems and embedded Rust development, you
-may find these resources useful.
-
-## Operating System development tutorials in Rust on the Raspberry Pi
-
-[Operating System development tutorials in Rust on the Raspberry Pi] is a
-tutorial series for hobby OS developers who are new to ARM's 64 bit ARMv8-A
-architecture. The tutorials will give a guided, step-by-step tour of how to
-write a monolithic Operating System kernel for an embedded system from
-scratch. They cover implementation of common Operating Systems tasks, like
-writing to the serial console, setting up virtual memory and handling hardware
-exceptions. All while leveraging Rust's unique features to provide for safety
-and speed.
-
-[Operating System development tutorials in Rust on the Raspberry Pi]: https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials


### PR DESCRIPTION
It's a great resource and adding it here would help to discover it for interested people.

I took the description from https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials .

Closes https://github.com/rust-embedded/docs/issues/16